### PR TITLE
Fix visible iframe pixel for Samsung Tizen devices

### DIFF
--- a/tracking-templates/iframe-loader.js
+++ b/tracking-templates/iframe-loader.js
@@ -57,7 +57,7 @@
 
         var iframe = document.createElement('iframe');
         iframe.setAttribute('src', '{{IFRAME_SERVER_URL}}' + getQuery());
-        iframe.setAttribute('style', 'position:fixed; border:0; outline:0; top:0; left:0; width:1px; height:1px;');
+        iframe.setAttribute('style', 'position:fixed;border:0;outline:0;top:-999px;left:-999px;width:0;height:0;');
         iframe.setAttribute('frameborder', '0');
         document.getElementsByTagName('body')[0].appendChild(iframe);
 


### PR DESCRIPTION
Pro7 reported that the iFrame pixel is visible on Samsung Tizen devices and suggested to move the pixel out of the viewport.

Resolves [TGTB-312](https://tvinsight.atlassian.net/browse/TGTB-312)

[TGTB-312]: https://tvinsight.atlassian.net/browse/TGTB-312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ