### PR TITLE
Do not restart tracking on switchChannel if stopped

### DIFF
--- a/tracking-templates/tracking.js
+++ b/tracking-templates/tracking.js
@@ -14,11 +14,13 @@
   };
   g._skip = init_suspended;
   g.switchChannel = function(id, r, d, cb, cb_err) {
+    var resume = g._timer;
     g.stop();
     cid = id;
     rs = r || 0;
     dl = d || 0;
-    if (cb) g.start(cb, cb_err);
+    if (resume) g.start(cb, cb_err);
+    if (!resume && cb) cb(true);
   };
   g.stop = function(cb) {
     try {


### PR DESCRIPTION
If the tracking was stopped before calling switchChannel, the tracking should still be in stopped state afterwards. Right now the tracking is started again when this method is called.

Resolves [TGTB-307](https://tvinsight.atlassian.net/browse/TGTB-307)