### PR TITLE
bugfix session end timestamp storing

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         id: install
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get latest version
         id: get-latest-version
@@ -67,7 +67,7 @@ jobs:
 
       - name: Create release
         id: create-release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: ${{ steps.create-snapshot-tag.outputs.version }}
           tag_name: ${{ steps.create-snapshot-tag.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         id: install
@@ -38,14 +38,14 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Zip release
         run: zip -r -j templates.zip ./tracking-templates/*
 
       - name: Create release
         id: create-release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: ${{  github.ref_name }}
           files: |

--- a/spec/sessionEndUpload.spec.js
+++ b/spec/sessionEndUpload.spec.js
@@ -75,7 +75,7 @@ describe.each(cases)("Session End Upload - Consent: %s - iFrame: %s", (consent, 
 
         await wait(2000);
         await page.evaluate(
-          `(new Promise((resolve)=>{__hbb_tracking_tgt.switchChannel(${CHANNEL_ID_TEST_B}, 1, 1, resolve)}))`,
+          `(new Promise((resolve)=>{__hbb_tracking_tgt.switchChannel(${CHANNEL_ID_TEST_A}, 1, 1, resolve)}))`,
         );
         const regex2 = new RegExp(`${sessIdSecondSession}/\\d*/e\\.gif`);
         await page.waitForResponse((request) => regex2.test(request.url()));

--- a/spec/sessionEndUpload.spec.js
+++ b/spec/sessionEndUpload.spec.js
@@ -17,6 +17,7 @@ let page;
 describe.each(cases)("Session End Upload - Consent: %s - iFrame: %s", (consent, iFrame) => {
   describe("when tracking is started", () => {
     let sessIdFirstSession;
+    let sessIdSecondSession;
 
     beforeEach(async () => {
       const userAgent = !iFrame
@@ -50,7 +51,7 @@ describe.each(cases)("Session End Upload - Consent: %s - iFrame: %s", (consent, 
       }, 10000);
     });
 
-    describe("and switchChannel is called", () => {
+    describe("and switchChannel is called once", () => {
       it(`should upload previous sessions's end timestamp`, async () => {
         await wait(2000);
         await page.evaluate(
@@ -59,6 +60,26 @@ describe.each(cases)("Session End Upload - Consent: %s - iFrame: %s", (consent, 
         const regex = new RegExp(`${sessIdFirstSession}/\\d*/e\\.gif`);
         await page.waitForResponse((request) => regex.test(request.url()));
       }, 10000);
+    });
+
+    describe("and switchChannel is called twice", () => {
+      it(`should upload previous sessions's end timestamp`, async () => {
+        await wait(2000);
+        await page.evaluate(
+          `(new Promise((resolve)=>{__hbb_tracking_tgt.switchChannel(${CHANNEL_ID_TEST_B}, 1, 1, resolve)}))`,
+        );
+        const regex1 = new RegExp(`${sessIdFirstSession}/\\d*/e\\.gif`);
+        await page.waitForResponse((request) => regex1.test(request.url()));
+
+        sessIdSecondSession = await page.evaluate(`(new Promise((resolve)=>{__hbb_tracking_tgt.getSID(resolve)}))`);
+
+        await wait(2000);
+        await page.evaluate(
+          `(new Promise((resolve)=>{__hbb_tracking_tgt.switchChannel(${CHANNEL_ID_TEST_B}, 1, 1, resolve)}))`,
+        );
+        const regex2 = new RegExp(`${sessIdSecondSession}/\\d*/e\\.gif`);
+        await page.waitForResponse((request) => regex2.test(request.url()));
+      }, 20000);
     });
   });
 });

--- a/spec/sessionEndUpload.spec.js
+++ b/spec/sessionEndUpload.spec.js
@@ -71,6 +71,7 @@ describe.each(cases)("Session End Upload - Consent: %s - iFrame: %s", (consent, 
         const regex1 = new RegExp(`${sessIdFirstSession}/\\d*/e\\.gif`);
         await page.waitForResponse((request) => regex1.test(request.url()));
 
+        await page.waitForResponse((request) => request.url().includes("i.gif"));
         sessIdSecondSession = await page.evaluate(`(new Promise((resolve)=>{__hbb_tracking_tgt.getSID(resolve)}))`);
 
         await wait(2000);

--- a/tracking-templates/new_session.js
+++ b/tracking-templates/new_session.js
@@ -3,24 +3,21 @@
   var g = window['{{TRACKING_GLOBAL_OBJECT}}'];
   g._hb = '{{HEARTBEAT_URL}}/';
   g._h = '{{HEARTBEAT_QUERY}}';
-  g.getDID = function(cb) {
-    if (cb) setTimeout(function() { cb('{{DEVICE_ID}}') }, 0);
-  };
-  g.getSID = function(cb) {
-    if (cb) setTimeout(function() { cb('{{SESSION_ID}}') }, 0);
-  };
+  g._cid = '{{CID}}';
+  g._did = '{{DEVICE_ID}}';
+  g._sid = '{{SESSION_ID}}';
   g.stop();
   if (g._lsAvailable) {
     g._closeActiveSessEnd();
     g._sessEndUpload();
   }
   if({{TRACKING_ENABLED}}) {
-    g._hbTimer = setInterval(function() { g._beat('{{CID}}') }, {{HEARTBEAT_INTERVAL}});
+    g._hbTimer = setInterval(g._beat, {{HEARTBEAT_INTERVAL}});
     if (g._lsAvailable) {
-      g._updateSessEndTimer = setInterval(function() { g._updateSessEndTs('{{SESSION_ID}}') }, 1000);
+      g._updateSessEndTimer = setInterval(g._updateSessEndTs, 1000);
     }
     if (g._log) {
-      g._log(LOG_EVENT_TYPE.S_STRT, 'sid={{SESSION_ID}},did={{DEVICE_ID}},cid={{CID}}');
+      g._log(LOG_EVENT_TYPE.S_STRT, 'sid='+g._sid+',did='+g._did+'},cid='+g._cid);
     }
   }
   try {

--- a/tracking-templates/new_session.js
+++ b/tracking-templates/new_session.js
@@ -17,7 +17,7 @@
       g._updateSessEndTimer = setInterval(g._updateSessEndTs, 1000);
     }
     if (g._log) {
-      g._log(LOG_EVENT_TYPE.S_STRT, 'sid='+g._sid+',did='+g._did+'},cid='+g._cid);
+      g._log(LOG_EVENT_TYPE.S_STRT, 'sid='+g._sid+',did='+g._did+',cid='+g._cid);
     }
   }
   try {

--- a/tracking-templates/tracking.js
+++ b/tracking-templates/tracking.js
@@ -40,7 +40,7 @@
   }
   function isLocalStorageAvailable() {
     try {
-      var key = 'a1b2c3d4-0000-eeee-8888-a1b2c3d4e5f6';
+      var key = 'a';
       var value = Date.now() + '';
       localStorage.setItem('lst', serializeSessionEnds({ [key]: value }));
       var deserialized = deserializeSessionEnds(localStorage.getItem('lst'));

--- a/tracking-templates/tracking.js
+++ b/tracking-templates/tracking.js
@@ -32,7 +32,9 @@
     var deserialized = {};
     for (var i=0; i<sessionEndEntries.length; i++) {
       var split = sessionEndEntries[i].split('=');
-      deserialized[split[0]] = split[1]
+      if (split[0] && split[1]) {
+        deserialized[split[0]] = split[1]
+      }
     }
     return deserialized;
   }

--- a/tracking-templates/tracking.js
+++ b/tracking-templates/tracking.js
@@ -18,11 +18,14 @@
   g._cb = {};
   g._hb = '{{HEARTBEAT_URL}}/';
   g._h = '{{HEARTBEAT_QUERY}}';
+  g._cid = '{{CID}}';
+  g._did = '{{DEVICE_ID}}';
+  g._sid = '{{SESSION_ID}}';
   g.getDID = function(cb) {
-    if (cb) setTimeout(function() { cb('{{DEVICE_ID}}') }, 0);
+    if (cb) setTimeout(function() { cb(g._did) }, 0);
   };
   g.getSID = function(cb) {
-    if (cb) setTimeout(function() { cb('{{SESSION_ID}}') }, 0);
+    if (cb) setTimeout(function() { cb(g._sid) }, 0);
   };
   g.switchChannel = function(id, r, d, cb, cb_err) {
     var resume = g._hbTimer;
@@ -43,14 +46,13 @@
         clearInterval(g._updateSessEndTimer);
         if (g._log) g._log(LOG_EVENT_TYPE.SE_UPDATE_STOP);
       }
-      g._updateSessEndTs();
     } catch(e) {}
     g._hbTimer = 0;
     g._updateSessEndTimer = 0;
     if (cb) setTimeout(function() { cb() }, 1);
   };
   g.start = function(cb, cb_err) {
-    var cid = typeof tcid !== 'undefined' ? tcid : '{{CID}}';
+    var cid = typeof tcid !== 'undefined' ? tcid : g._cid;
     g._send('{{NEW_SESSION}}'+cid+'&r='+rs+'&d='+dl, cb, cb_err);
   };
   g.onLogEvent = function(cb) {
@@ -80,9 +82,8 @@
     }
     if (g._log) g._log(LOG_EVENT_TYPE.HB_ERR);
   });
-  g._beat = function (c) {
+  g._beat = function () {
     try {
-      var cid = typeof c !== 'undefined' ? c : '{{CID}}';
       if(delay) return;
       if(stop > 0) {
         if (--stop === 0) err = 0;
@@ -90,7 +91,7 @@
         return;
       }
       delay = 1;
-      hbImg.setAttribute('src', g._hb + cid + g._h + Date.now() + '/{{PIXEL_NAME}}?f={{HEARTBEAT_INTERVAL}}');
+      hbImg.setAttribute('src', g._hb + g._cid + g._h + Date.now() + '/{{PIXEL_NAME}}?f={{HEARTBEAT_INTERVAL}}');
       if (g._log) g._log(LOG_EVENT_TYPE.HB_REQ);
     } catch(e) {}
   };
@@ -126,12 +127,11 @@
     }
     return deserialized;
   }
-  g._updateSessEndTs = function (s) {
+  g._updateSessEndTs = function () {
     if (!g._lsAvailable) return;
-    var sid = typeof s !== 'undefined' ? s : '{{SESSION_ID}}';
     var ts = Date.now();
-    localStorage.setItem('ase', sid+'='+ts);
-    if (g._log) g._log(LOG_EVENT_TYPE.SE_UPDATE, "sid="+sid+", ts="+ts);
+    localStorage.setItem('ase', g._sid+'='+ts);
+    if (g._log) g._log(LOG_EVENT_TYPE.SE_UPDATE, "sid="+g._sid+",ts="+ts);
   }
   g._closeActiveSessEnd = function () {
     if (!g._lsAvailable) return;
@@ -164,7 +164,7 @@
     } else {
       localStorage.setItem('pse', serializeSessionEnds(prevSessionEnds));
     }
-    if (g._log) g._log(LOG_EVENT_TYPE.SE_SEND, "sid="+sid+", ts="+ts );
+    if (g._log) g._log(LOG_EVENT_TYPE.SE_SEND, "sid="+sid+",ts="+ts );
   }
   function uploadSessionEnd (sid, ts, retries, successCB, errorCB) {
     try {
@@ -206,9 +206,9 @@
     if (g._log) g._log(LOG_EVENT_TYPE.SE_UPDATE_START);
   }
   if(has_consent && g._lsAvailable) {
-    localStorage.setItem('did', '{{DEVICE_ID}}');
+    localStorage.setItem('did', g._did);
   }
   if (g._log) {
-    g._log(LOG_EVENT_TYPE.S_STRT, 'sid={{SESSION_ID}},did={{DEVICE_ID}},cid={{CID}}');
+    g._log(LOG_EVENT_TYPE.S_STRT, 'sid='+g._sid+',did='+g._did+',cid='+g._cid);
   }
 })();


### PR DESCRIPTION
### Bug
When the switchChannel method is used consecutively, the session-end timestamp is always stored for first used session-id, and therefore uploaded multiple times for the same session

### Further changes
- https://github.com/rbredtech/tv-insight-hbbtv-tracking-script/pull/12/files#diff-a4e0af13f82f44c88e43e98c1ac1a282470839cf5fd317fe6bdf41310aa7927aL46: Call of `_updateSessEndTS` was removed, as it can lead to set the session-end timestamp wrongly if `stop()` is called ahead of `switchChannel()`, as it updates the session-end timestamp after it was manually stopped.

- https://github.com/rbredtech/tv-insight-hbbtv-tracking-script/pull/12/files#diff-3c3e58e61f92d41c02fb37cac41c093af2378d7fb1293e064609eb817c668774R6 and https://github.com/rbredtech/tv-insight-hbbtv-tracking-script/pull/12/files#diff-a4e0af13f82f44c88e43e98c1ac1a282470839cf5fd317fe6bdf41310aa7927aR68: By storing the template variables on the global object, overwriting the `getDID` and `getSID` methods gets unnecessary, and also allows for simplified restarting of heartbeats and session-end updates without having to pass the updated values.