### PR TITLE
TVI-2161 - channel name from oipfApplicationManager

### DIFF
--- a/tracking-templates/iframe-loader.js
+++ b/tracking-templates/iframe-loader.js
@@ -20,13 +20,10 @@
     g.onLogEvent = function() {
         g._q[g._q.length] = {m: 'onLogEvent', a: Array.prototype.slice.call(arguments)};
     }
-    var has_consent={{CONSENT}};
-    var init_suspended={{INITIALIZE_SUSPENDED}};
-    var ls=!!window.localStorage && !!localStorage.getItem && !!localStorage.setItem && !!localStorage.removeItem;
-    function getMeta() {
+    g._sendMeta = function() {
         try {
             if (!window['{{TRACKING_GLOBAL_OBJECT}}']) {
-                setTimeout(getMeta, 1000);
+                setTimeout(g._sendMeta, 1000);
                 return;
             }
             var objs = document.getElementsByTagName('object');
@@ -34,7 +31,12 @@
             for (var i=0; i<objs.length; i++) {
                 if (objs[i].type === 'application/oipfApplicationManager') mgr = objs[i];
             }
-            if (!mgr) return;
+            if (!mgr) {
+                var el = document.createElement('object');
+                el.type = 'application/oipfApplicationManager';
+                document.body.appendChild(el);
+                mgr = el;
+            };
             var app = mgr.getOwnerApplication(document);
             if (app && app.privateData && app.privateData.currentChannel) {
                 var curr = app.privateData.currentChannel;
@@ -42,16 +44,20 @@
                 var ccid = curr.ccid || '-1';
                 var onid = curr.onid || '-1';
                 var nid = curr.nid || '-1';
+                var name = curr.name || 'undefined';
 
                 var req = new XMLHttpRequest();
                 window['{{TRACKING_GLOBAL_OBJECT}}'].getSID(function(sid) {
-                    var m = '?sid=' + sid + '&idtype=' + idtype + '&ccid=' + ccid + '&onid=' + onid + '&nid=' + nid;
+                    var m = '?sid=' + sid + '&idtype=' + idtype + '&ccid=' + ccid + '&onid=' + onid + '&nid=' + nid+ '&name=' + name;
                     req.open('GET', '{{SESSION_SERVER_URL}}/meta' + m);
                     req.send();
                 });
             }
         } catch(e) {}
     }
+    var has_consent={{CONSENT}};
+    var init_suspended={{INITIALIZE_SUSPENDED}};
+    var ls=!!window.localStorage && !!localStorage.getItem && !!localStorage.setItem && !!localStorage.removeItem;
     function getQuery(did) {
         return '{{CID}}&r={{RESOLUTION}}&d={{DELIVERY}}' + (did ? '&did=' + did : '') + '&suspended=' + init_suspended + '&ls=' + ls + '&ts=' + Date.now() + '{{OTHER_QUERY_PARAMS}}';
     }
@@ -88,7 +94,10 @@
                 message('stop', function(r) {cb && cb(r === '1')});
             };
             g.start = function(cb, cb_err) {
-                message('start', function(r) {cb && cb(r === '1')}, cb_err);
+                message('start', function(r) {
+                    cb && cb(r === '1');
+                    setTimeout(g._sendMeta, 1);
+                }, cb_err);
             };
             g.onLogEvent = function(cb) {
                 message('log', function(r) {cb && cb.apply(null, r.split(':').map(function(e, i){return i === 0 ? parseInt(e, 10) : e}))});
@@ -154,5 +163,5 @@
         if (!has_consent && ls) localStorage.removeItem('did');
     }
 
-    setTimeout(getMeta, 1);
+    setTimeout(g._sendMeta, 1);
 } catch (e) {}})();

--- a/tracking-templates/new_session.js
+++ b/tracking-templates/new_session.js
@@ -19,6 +19,9 @@
     if (g._log) {
       g._log(LOG_EVENT_TYPE.S_STRT, 'sid='+g._sid+',did='+g._did+',cid='+g._cid);
     }
+    if (g._sendMeta) {
+      setTimeout(g._sendMeta, 1);
+    }
   }
   try {
     var cb = g._cb['{{CB}}'];


### PR DESCRIPTION
Currently, on loading the tracking script, meta information about the tuned in channel is read from the `oipfApplicationManger` object and sent to the `/meta` endpoint. With this change, this information is
- extended to also include the channel name and
- sent also on starting a new session (e.g. when `switchChannel` is called)

We want to collect this information to evaluate if it can be used in the future to auto-detect the tuned in channel to make integration of the tracking script independent of manually supplied parameters.