### PR TITLE
Make session-end object construction compatible with older engines

### DIFF
--- a/tracking-templates/tracking.js
+++ b/tracking-templates/tracking.js
@@ -42,7 +42,9 @@
     try {
       var key = 'a';
       var value = Date.now() + '';
-      localStorage.setItem('lst', serializeSessionEnds({ [key]: value }));
+      var sessionEnd = {};
+      sessionEnd[key] = value;
+      localStorage.setItem('lst', serializeSessionEnds(sessionEnd));
       var deserialized = deserializeSessionEnds(localStorage.getItem('lst'));
       localStorage.removeItem('lst');
       if (!deserialized[key] || deserialized[key] !== value) return false;


### PR DESCRIPTION
Some older JS engines do not support shorthand object creation which can cause a compilation error at runtime. Therefore, we change to the more verbose method of object creation which is compatible with wide range of JS engines.