### PR TITLE
Add check for getOwnerApplication availability

### DIFF
--- a/mock-session-application/puppeteer.html
+++ b/mock-session-application/puppeteer.html
@@ -49,7 +49,9 @@
     //]]>
   </script>
   <script type="text/javascript">
-    document.getElementById("applicationManager").getOwnerApplication = function () {
+    var applicationManager = document.getElementById("applicationManager");
+    if (!applicationManager.getOwnerApplication) {
+      applicationManager.getOwnerApplication = function () {
         return {
           privateData: {
             currentChannel: {
@@ -62,7 +64,8 @@
             },
           },
         };
-      };
+      }
+    }
   </script>
 </body>
 

--- a/spec/core.spec.js
+++ b/spec/core.spec.js
@@ -41,7 +41,7 @@ describe.each(cases)("Core Tracking Functionalities - Consent: %s - iFrame: %s",
           waitUntil: "domcontentloaded",
         },
       );
-      metaCalled = page.waitForResponse((request) => request.url().includes(`/meta`));
+      metaCalled = page.waitForResponse((request) => request.url().includes(`/meta.gif`));
       trackingScriptResponse = await page.waitForResponse((request) => request.url().includes("tracking.js"));
       trackingRequestDeferred = page.waitForRequest((request) => request.url().includes(iFrame ? "ra_if.js" : "ra.js"));
     }, 20000);

--- a/spec/switchChannel.spec.js
+++ b/spec/switchChannel.spec.js
@@ -70,7 +70,7 @@ describe.each(cases)("Switch Channel functionality - Consent: %s - iFrame: %s", 
         let switchChannelResult, metaCalled, newSid;
 
         beforeAll(async () => {
-          metaCalled = page.waitForResponse((request) => request.url().includes(`/meta`));
+          metaCalled = page.waitForResponse((request) => request.url().includes(`/meta.gif`));
           switchChannelResult = await page.evaluate(
             `(new Promise((resolve)=>{__hbb_tracking_tgt.switchChannel(${CHANNEL_ID_TEST_B},${resolution},${delivery},resolve)}))`,
           );

--- a/tracking-templates/iframe-loader.js
+++ b/tracking-templates/iframe-loader.js
@@ -2,7 +2,9 @@
   function objectKeys(obj) {
     var keys = [];
     for (var key in obj) {
-      keys.push(key);
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        keys.push(key);
+      }
     }
     return keys;
   }

--- a/tracking-templates/iframe-loader.js
+++ b/tracking-templates/iframe-loader.js
@@ -81,7 +81,7 @@
                 document.body.appendChild(el);
                 mgr = el;
             };
-            var app = mgr.getOwnerApplication(document);
+            var app = typeof mgr.getOwnerApplication === 'function' ? mgr.getOwnerApplication(document) : null;
             var m  = '';
             if (app && app.privateData && app.privateData.currentChannel) {
                 var curr = app.privateData.currentChannel;

--- a/tracking-templates/iframe-loader.js
+++ b/tracking-templates/iframe-loader.js
@@ -25,14 +25,14 @@
     return serialized;
   }
   function getSamplerPercentile(callback) {
-    if (!window.__tvi_sampler) {
+    if (!window.__tvi_sampler || !window.__tvi_sampler.getPercentile || typeof window.__tvi_sampler.getPercentile !== "function") {
       callback(undefined);
       return;
     }
     window.__tvi_sampler.getPercentile(callback);
   }
   function getConsentStatus(callback) {
-    if (!window.__cmpapi) {
+    if (!window.__cmpapi || typeof window.__cmpapi !== "function") {
         callback(undefined);
         return;
     }

--- a/tracking-templates/tracking.js
+++ b/tracking-templates/tracking.js
@@ -7,7 +7,9 @@
   function objectKeys(obj) {
     var keys = [];
     for (var key in obj) {
-      keys.push(key);
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        keys.push(key);
+      }
     }
     return keys;
   }


### PR DESCRIPTION
This PR introduces the following changes:
- `getOwnerApplication` availability gets checked before using. This catches possible cases of unavailability due to cross-domain restrictions
- improved checks for tvi-sampler/cmpapi availability
- added `hasOwnProperty` check to for-in usage (to avoid iterating prototype props)