### PR TITLE
remove sending data to meta-endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The repository contains TV-Insight HbbTv tracking script content templates.
 │  │  - Detects device capabilities                          │    │
 │  │  - Creates API stub (queues calls)                      │    │
 │  │  - Loads tracking via iframe OR direct script           │    │
-│  │  - Sends channel metadata                               │    │
 │  └─────────────────────────────────────────────────────────┘    │
 │                            │                                    │
 │              ┌─────────────┴─────────────┐                      │
@@ -109,7 +108,7 @@ The following placeholders are replaced at runtime by the backend. Each placehol
 | ---------------------------| -------------------------------------------------------------------|
 | `{{IFRAME_SERVER_URL}}`   | URL for loading the tracking iframe (`iframe.html`)               |
 | `{{RA_SERVER_URL}}`       | URL for loading the tracking script directly (legacy/direct mode) |
-| `{{SESSION_SERVER_URL}}`  | Backend URL for metadata requests                                 |
+| `{{SESSION_SERVER_URL}}`  | Backend URL for script requests                                   |
 | `{{SESSION_SERVER_HOST}}` | Origin of the session server (used for postMessage validation)    |
 | `{{OTHER_QUERY_PARAMS}}`  | Additional query parameters appended to requests                  |
 
@@ -186,28 +185,7 @@ https://docs.tv-insight.com/docs/hbbtv-tracking/hbbtv-tracking-script
 
 ## OIPF DAE Compliance
 
-The implementation follows the OIPF DAE specification (Volume 5, Declarative Application Environment):
-
-### Application Management APIs (Section 7.2)
-
-- Uses `application/oipfApplicationManager` embedded object (Section 7.2.1)
-- Calls `getOwnerApplication(document)` to get the Application object
-- Accesses `ApplicationPrivateData.currentChannel` for channel information (Section 7.2.4)
-
-### Channel Class Properties (Section 7.13.11.2)
-
-The following Channel properties are collected for metadata:
-
-| Property | Description                                 |
-| ----------| ---------------------------------------------|
-| `idType` | Type of channel (ID_DVB_*, ID_IPTV_*, etc.) |
-| `ccid`   | Unique identifier within OITF scope         |
-| `onid`   | Original Network ID (DVB/ISDB)              |
-| `tsid`   | Transport Stream ID (DVB/ISDB)              |
-| `sid`    | Service ID (DVB/ISDB)                       |
-| `nid`    | Network ID (broadcaster extension)          |
-| `name`   | Channel name                                |
-| `isHD`   | HD flag                                     |
+The implementation follows the OIPF DAE specification (Volume 5, Declarative Application Environment).
 
 ### Reference Documents
 

--- a/mock-session-application/index.ts
+++ b/mock-session-application/index.ts
@@ -162,15 +162,6 @@ app.get("/new.js", (req, res) => {
   res.send(content);
 });
 
-app.get("/meta", (_req, res) => {
-  res.setHeader("Content-Type", "text/javascript");
-  res.send("").status(200);
-});
-
-app.get("/meta.gif", (_req, res) => {
-  res.sendFile(path.join(__dirname, "pixel.gif"));
-});
-
 app.get("/:channelId/:did/:sid/:ts/i.gif", (_req, res) => {
   res.sendFile(path.join(__dirname, "pixel.gif"));
 });

--- a/spec/core.spec.js
+++ b/spec/core.spec.js
@@ -29,7 +29,7 @@ describe.each(cases)("Core Tracking Functionalities - Consent: %s - iFrame: %s",
   }, 20000);
 
   describe("when tracking is started", () => {
-    let trackingScriptResponse, trackingRequestDeferred, metaCalled;
+    let trackingScriptResponse, trackingRequestDeferred;
     beforeAll(async () => {
       page.goto(
         `http://localhost:3000/puppeteer.html?cid=${channelId}&r=${resolution}&d=${delivery}&c=${consent}&suspended=${suspended}`,
@@ -37,7 +37,6 @@ describe.each(cases)("Core Tracking Functionalities - Consent: %s - iFrame: %s",
           waitUntil: "domcontentloaded",
         },
       );
-      metaCalled = page.waitForResponse((request) => request.url().includes(`/meta.gif`));
       trackingScriptResponse = await page.waitForResponse((request) => request.url().includes("tracking.js"));
       trackingRequestDeferred = page.waitForRequest((request) => request.url().includes(iFrame ? "ra_if.js" : "ra.js"));
     }, 20000);
@@ -49,11 +48,6 @@ describe.each(cases)("Core Tracking Functionalities - Consent: %s - iFrame: %s",
     it("should create heartbeat request", async () => {
       const httpResponse = await page.waitForResponse((response) => response.url().includes("i.gif"));
       expect(httpResponse.status()).toBe(200);
-    });
-
-    it("should send channel meta information", async () => {
-      const httpResponse = await metaCalled;
-      expect(httpResponse.ok()).toBe(true);
     });
 
     it("should create device ID", async () => {

--- a/spec/stop.spec.js
+++ b/spec/stop.spec.js
@@ -16,11 +16,9 @@ let page;
 
 describe.each(cases)("Stop behavior - Consent: %s - iFrame: %s", (consent, iFrame) => {
   let heartbeatCount;
-  let metaCount;
 
   beforeEach(async () => {
     heartbeatCount = 0;
-    metaCount = 0;
 
     page = await pageHelper.get(iFrame);
 
@@ -28,9 +26,6 @@ describe.each(cases)("Stop behavior - Consent: %s - iFrame: %s", (consent, iFram
       var url = req.url();
       if (url.indexOf("i.gif") >= 0) {
         heartbeatCount++;
-      }
-      if (url.indexOf("/meta.gif") >= 0) {
-        metaCount++;
       }
     });
 
@@ -48,18 +43,14 @@ describe.each(cases)("Stop behavior - Consent: %s - iFrame: %s", (consent, iFram
     await page.browser().close();
   }, 20000);
 
-  it("stop() should stop subsequent heartbeat requests and cancel scheduled meta", async () => {
-    // Call stop early (before the 5s meta timeout fires).
+  it("stop() should stop subsequent heartbeat requests", async () => {
+    // Call stop early.
     await page.evaluate(`(new Promise((resolve)=>{__hbb_tracking_tgt.stop(resolve)}))`);
-
     var heartbeatCountAfterStop = heartbeatCount;
-    var metaCountAfterStop = metaCount;
-
-    // Wait long enough for multiple heartbeat intervals and the meta timeout (5s)
+    // Wait long enough for multiple heartbeat intervals (5s)
     await wait(6500);
 
     expect(heartbeatCount).toEqual(heartbeatCountAfterStop);
-    expect(metaCount).toBe(metaCountAfterStop);
   }, 20000);
 
   it("stop() before switchChannel() should prevent heartbeats until start() is called", async () => {

--- a/spec/switchChannel.spec.js
+++ b/spec/switchChannel.spec.js
@@ -62,10 +62,9 @@ describe.each(cases)("Switch Channel functionality - Consent: %s - iFrame: %s", 
       });
 
       describe("AND switchChannel() API method is called", () => {
-        let switchChannelResult, metaCalled, newSid;
+        let switchChannelResult, newSid;
 
         beforeAll(async () => {
-          metaCalled = page.waitForResponse((request) => request.url().includes(`/meta.gif`));
           switchChannelResult = await page.evaluate(
             `(new Promise((resolve)=>{__hbb_tracking_tgt.switchChannel(${CHANNEL_ID_TEST_B},${resolution},${delivery},resolve)}))`,
           );
@@ -79,13 +78,6 @@ describe.each(cases)("Switch Channel functionality - Consent: %s - iFrame: %s", 
           newSid = await page.evaluate(`(new Promise((resolve)=>{__hbb_tracking_tgt.getSID(resolve)}))`);
           expect(newSid).not.toBe(sid);
         });
-
-        it("should call /meta.gif endpoint", async () => {
-          const response = await metaCalled;
-          expect(response.url()).toBe(
-            `http://localhost:3000/meta.gif?idtype=1&ccid=1&onid=1&nid=1&name=TEST&isHD=true&sid=${newSid}`,
-          );
-        }, 10000);
 
         it("should create stop and start log entries", async () => {
           const logSessionStartEntries = await page.evaluate(`getLogEntries(5)`);

--- a/src/iframe-loader.js
+++ b/src/iframe-loader.js
@@ -13,19 +13,6 @@
   // ============================================================================
 
   /**
-   * ES3-safe Object.keys implementation
-   */
-  function objectKeys(obj) {
-    var keys = [];
-    for (var key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        keys[keys.length] = key;
-      }
-    }
-    return keys;
-  }
-
-  /**
    * Check if localStorage is available
    */
   function isLocalStorageAvailable() {
@@ -78,72 +65,6 @@
 
   // User agents that don't support iframe mode
   var BLOCKED_USER_AGENTS = ['antgalio', 'hybrid', 'maple', 'presto', 'technotrend goerler', 'viera 2011'];
-
-  // ============================================================================
-  // CONSENT / CMP INTEGRATION
-  // ============================================================================
-
-  /**
-   * Serialize consent by vendor ID to string format: "vendorId1~consent1,vendorId2~consent2"
-   */
-  function serializeConsentByVendorId(consentByVendorId) {
-    if (!consentByVendorId) return undefined;
-
-    try {
-      var vendorIds = objectKeys(consentByVendorId);
-      var result = '';
-
-      for (var i = 0; i < vendorIds.length; i++) {
-        if (i > 0) result += ',';
-        result += vendorIds[i] + '~' + consentByVendorId[vendorIds[i]];
-      }
-      return result;
-    } catch (e) {
-      return undefined;
-    }
-  }
-
-  /**
-   * Get consent status from CMP API
-   */
-  function getConsentStatus(callback) {
-    if (!window.__cmpapi || typeof window.__cmpapi !== 'function') {
-      callback(undefined);
-      return;
-    }
-
-    try {
-      window.__cmpapi('getTCData', 2, function (tcData) {
-        if (!tcData || tcData.cmpStatus !== 'loaded') {
-          callback(undefined);
-          return;
-        }
-        callback(tcData.vendor && tcData.vendor.consents);
-      });
-    } catch (e) {
-      callback(undefined);
-    }
-  }
-
-  /**
-   * Get sampler percentile from sampler API
-   */
-  function getSamplerPercentile(callback) {
-    if (
-      !window.__tvi_sampler ||
-      !window.__tvi_sampler.getPercentile ||
-      typeof window.__tvi_sampler.getPercentile !== 'function'
-    ) {
-      callback(undefined);
-      return;
-    }
-
-    try {
-      window.__tvi_sampler.getPercentile(callback);
-    } catch (e) {
-      callback(undefined);
-    }
-  }
 
   // ============================================================================
   // API STUB (queues calls until tracking is loaded)

--- a/src/new_session.js
+++ b/src/new_session.js
@@ -64,15 +64,6 @@
     );
   }
 
-  function scheduleMetadataSend() {
-    if (!globalApi._sendMeta) {
-      return;
-    }
-
-    clearTimeout(globalApi._sendMetaTimeout);
-    globalApi._sendMetaTimeout = setTimeout(globalApi._sendMeta, 5000);
-  }
-
   function executeCallback() {
     try {
       var callback = globalApi._cb[CONSTANTS.CALLBACK_ID];
@@ -90,7 +81,6 @@
     if (CONSTANTS.TRACKING_ENABLED) {
       startTracking();
     }
-    scheduleMetadataSend();
     executeCallback();
   });
 })();

--- a/src/tracking.js
+++ b/src/tracking.js
@@ -540,10 +540,6 @@
     apiContext._log = function (type, message) {
       log(type, message);
     };
-
-    apiContext._send = function (url, callback, errorCallback) {
-      loadScript(withCallback(url, this, callback), null, errorCallback);
-    };
   }
 
   // ============================================================================

--- a/src/tracking.js
+++ b/src/tracking.js
@@ -445,7 +445,6 @@
       try {
         this._stopHeartbeatInterval();
         this._stopSessionEndUpdates();
-        this._cancelMeta();
       } catch (e) {}
 
       if (callback) {
@@ -524,14 +523,6 @@
       clearInterval(this._updateSessEndTimer);
       this._updateSessEndTimer = null;
       log(LOG_EVENT.SESSION_END_UPDATE_STOP);
-    };
-
-    apiContext._cancelMeta = function () {
-      if (!this._sendMetaTimeout) {
-        return;
-      }
-      clearTimeout(this._sendMetaTimeout);
-      this._sendMetaTimeout = null;
     };
 
     apiContext._updateSessEndTs = function () {

--- a/src/tracking.js
+++ b/src/tracking.js
@@ -549,10 +549,6 @@
     apiContext._log = function (type, message) {
       log(type, message);
     };
-
-    apiContext._send = function (url, callback, errorCallback) {
-      loadScript(withCallback(url, this, callback), null, errorCallback);
-    };
   }
 
   // ============================================================================


### PR DESCRIPTION
As the data sent to the meta-endpoint (meta.gif) is not used at all, we want to remove this functionality entirely.